### PR TITLE
standardize agent task apis

### DIFF
--- a/teamserver/internal/api/handlers/agent_handler.go
+++ b/teamserver/internal/api/handlers/agent_handler.go
@@ -19,15 +19,15 @@ func NewAgentController(dal *dal.AgentDAL) *AgentController {
 }
 
 func (ac *AgentController) GetAgent(ctx *gin.Context) {
-	agentID := ctx.Param("id")
+	agentID := ctx.Param(models.ParamAgentID)
 	if agentID == "" {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "agent_id is required"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%s is required", models.ParamAgentID)})
 		return
 	}
 
 	agent, err := ac.dal.GetAgent(agentID)
 	if err != nil {
-		ctx.JSON(http.StatusNotFound, fmt.Sprintf("Agent not found: %s", err.Error()))
+		ctx.JSON(http.StatusNotFound, fmt.Sprintf("Agent %s not found: %s", agentID, err.Error()))
 		return
 	}
 
@@ -39,16 +39,16 @@ func (ac *AgentController) GetAgent(ctx *gin.Context) {
 func (ac *AgentController) UpdateAgent(ctx *gin.Context) {
 
 	// get the ID of the agent to be updated in the query params
-	agentID := ctx.Param("id")
+	agentID := ctx.Param(models.ParamAgentID)
 	if agentID == "" {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "agent_id is required"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%s is required", models.ParamAgentID)})
 		return
 	}
 
 	// Get the agent that is going to be updated in the db
 	agent, err := ac.dal.GetAgent(agentID)
 	if err != nil {
-		ctx.JSON(http.StatusNotFound, fmt.Sprintf("Agent not found: %s", err.Error()))
+		ctx.JSON(http.StatusNotFound, fmt.Sprintf("Agent %s not found: %s", agentID, err.Error()))
 		return
 	}
 
@@ -73,9 +73,9 @@ func (ac *AgentController) UpdateAgent(ctx *gin.Context) {
 }
 
 func (ac *AgentController) DeleteAgent(ctx *gin.Context) {
-	agentID := ctx.Param("id")
+	agentID := ctx.Param(models.ParamAgentID)
 	if agentID == "" {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "agent_id is required"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%s is required", models.ParamAgentID)})
 		return
 	}
 
@@ -92,9 +92,9 @@ func (ac *AgentController) DeleteAgent(ctx *gin.Context) {
 func (ac *AgentController) CreateAgentTask(ctx *gin.Context) {
 
 	// Get the agentID from the query params
-	agentID := ctx.Param("agent_id")
+	agentID := ctx.Param(models.ParamAgentID)
 	if agentID == "" {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "agent_id is required"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%s is required", models.ParamAgentID)})
 		return
 	}
 
@@ -118,7 +118,7 @@ func (ac *AgentController) CreateAgentTask(ctx *gin.Context) {
 }
 
 func (ac *AgentController) GetAgentTasks(ctx *gin.Context) {
-	agentID := ctx.Param("agent_id")
+	agentID := ctx.Param(models.ParamAgentID)
 
 	tasks, err := ac.dal.GetAgentTasks(ctx, agentID)
 	if err != nil {
@@ -131,10 +131,10 @@ func (ac *AgentController) GetAgentTasks(ctx *gin.Context) {
 
 // DeleteAgentTasks Deletes all tasks for a single agent
 func (ac *AgentController) DeleteAgentTasks(ctx *gin.Context) {
-	agentID := ctx.Param("agent_id")
+	agentID := ctx.Param(models.ParamAgentID)
 
 	if agentID == "" {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "agent_id is required"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%s is required", models.ParamAgentID)})
 		return
 	}
 
@@ -148,17 +148,17 @@ func (ac *AgentController) DeleteAgentTasks(ctx *gin.Context) {
 
 // DeleteAgentTask Delete a single task
 func (ac *AgentController) DeleteAgentTask(ctx *gin.Context) {
-	agentId := ctx.Param("agent_id")
+	agentId := ctx.Param(models.ParamAgentID)
 
 	if agentId == "" {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "agent_id is required"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%s is required", models.ParamAgentID)})
 		return
 	}
 
-	taskID := ctx.Param("task_id")
+	taskID := ctx.Param(models.ParamTaskID)
 
 	if taskID == "" {
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": "task_id is required"})
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%s is required", models.ParamTaskID)})
 		return
 	}
 
@@ -167,5 +167,5 @@ func (ac *AgentController) DeleteAgentTask(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, gin.H{})
+	ctx.JSON(http.StatusOK, gin.H{"message": fmt.Sprintf("Agent '%s' task '%s' deleted", agentId, taskID)})
 }

--- a/teamserver/internal/models/agent.go
+++ b/teamserver/internal/models/agent.go
@@ -4,6 +4,11 @@ import (
 	"time"
 )
 
+const (
+	ParamAgentID = "agent_id"
+	ParamTaskID  = "task_id"
+)
+
 // Contains all information required for controlling an agent.
 type Agent struct {
 	ID            string      `json:"id"`

--- a/teamserver/internal/server/server.go
+++ b/teamserver/internal/server/server.go
@@ -71,15 +71,15 @@ func (s *Server) RegisterRoutes() {
 
 			agentsGroup := v1Group.Group("/agents")
 			{
-				agentsGroup.GET("/", s.dependencies.AgentController.GetAgent)
-				agentsGroup.PUT("/", s.dependencies.AgentController.UpdateAgent)
-				agentsGroup.DELETE("/", s.dependencies.AgentController.DeleteAgent)
+				agentsGroup.GET(fmt.Sprintf("/:%s", models.ParamAgentID), s.dependencies.AgentController.GetAgent)
+				agentsGroup.PUT(fmt.Sprintf("/:%s", models.ParamAgentID), s.dependencies.AgentController.UpdateAgent)
+				agentsGroup.DELETE(fmt.Sprintf("/:%s", models.ParamAgentID), s.dependencies.AgentController.DeleteAgent)
 
 				// Agent Tasks API
 				agentsGroup.GET("/tasks", s.dependencies.AgentController.GetAgentTasks)
 				agentsGroup.POST("/tasks", s.dependencies.AgentController.CreateAgentTask)
-				agentsGroup.DELETE("/tasks", s.dependencies.AgentController.DeleteAgentTasks)
-				agentsGroup.DELETE("/tasks/task", s.dependencies.AgentController.DeleteAgentTask)
+				agentsGroup.DELETE(fmt.Sprintf(":%s/tasks", models.ParamAgentID), s.dependencies.AgentController.DeleteAgentTasks)
+				agentsGroup.DELETE(fmt.Sprintf(":%s/tasks/:%s", models.ParamAgentID, models.ParamTaskID), s.dependencies.AgentController.DeleteAgentTask)
 			}
 
 			checkinGroup := v1Group.Group("/checkin")


### PR DESCRIPTION
- added consts for agent parameters. they were scattered and used in the model, handlers and router. now they are defined in one placed and used across all modules.
- fixed agent task apis in server route as these were not accepting parameters.