### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/teamserver/internal/handlers/certificate_handler.go
+++ b/teamserver/internal/handlers/certificate_handler.go
@@ -63,11 +63,9 @@ func (h *CertificateHandler) UploadCertificate(ctx *gin.Context) {
 		return
 	}
 
-	// Create a unique filename to prevent overwriting
 	uploadPath := conf.GetCertUploadPath()
 	filename := fmt.Sprintf("%s-%s", certType, filepath.Base(file.Filename))
 	
-	// Validate filename to ensure it does not contain any path separators or parent directory references
 	if strings.Contains(filename, "/") || strings.Contains(filename, "\\") || strings.Contains(filename, "..") {
 		models.ResponseError(ctx, http.StatusBadRequest, "Invalid file name", "File name contains invalid characters")
 		return
@@ -75,7 +73,6 @@ func (h *CertificateHandler) UploadCertificate(ctx *gin.Context) {
 	
 	filePath := filepath.Join(uploadPath, filename)
 	
-	// Ensure the resolved path is within the safe directory
 	absPath, err := filepath.Abs(filePath)
 	if err != nil || !strings.HasPrefix(absPath, uploadPath) {
 		models.ResponseError(ctx, http.StatusBadRequest, "Invalid file path", "File path is outside the allowed directory")


### PR DESCRIPTION
Potential fix for [https://github.com/ksel172/Meduza/security/code-scanning/3](https://github.com/ksel172/Meduza/security/code-scanning/3)

To fix the problem, we need to ensure that the constructed file path is safe and does not allow directory traversal or other malicious file operations. We can achieve this by validating the `filename` to ensure it does not contain any path separators or parent directory references. Additionally, we can ensure that the resolved path is within a specific safe directory.

1. Validate the `filename` to ensure it does not contain any path separators or parent directory references.
2. Ensure that the resolved path is within the safe directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
