### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/teamserver/internal/handlers/payload_handler.go
+++ b/teamserver/internal/handlers/payload_handler.go
@@ -137,7 +137,12 @@ func (h *PayloadController) DeletePayload(ctx *gin.Context) {
 		return
 	}
 
-	filePath := "./teamserver/build/payload-" + payloadId
+	if !isValidPayloadID(payloadId) {
+		models.ResponseError(ctx, http.StatusBadRequest, "Invalid payload ID", fmt.Sprintf("%s contains invalid characters", payloadId))
+		return
+	}
+
+	filePath := filepath.Join("./teamserver/build", "payload-"+payloadId)
 	logger.Info(filePath)
 
 	if err := h.payloadDAL.DeletePayload(ctx.Request.Context(), payloadId); err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/ksel172/Meduza/security/code-scanning/4](https://github.com/ksel172/Meduza/security/code-scanning/4)

To address the issue, the user-provided value (`payloadId`) must be properly validated before constructing the file path. Since `payloadId` is expected to correspond to a specific payload identifier, it should be checked against an allowlist or validated to ensure it does not contain path traversal sequences (e.g., `..`, `/`, `\`) or other disallowed characters.

The best fix involves:
1. Using a validation function to ensure that `payloadId` is a valid single path component (e.g., alphanumeric characters and/or hyphens only).
2. Rejecting requests with invalid `payloadId` by returning an HTTP 400 error.
3. Constructing the file path using the validated `payloadId`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
