### PR TITLE
[NuLink] No HEALTHCHECK defined

### DIFF
--- a/teamserver/docker/Dockerfile
+++ b/teamserver/docker/Dockerfile
@@ -25,3 +25,6 @@ COPY ../.. .
 
 # Set the entry point for the container
 ENTRYPOINT ["./docker/init_ts.sh"]
+
+# Add a health check for the container
+HEALTHCHECK CMD curl --fail http://localhost:8080/health || exit 1


### PR DESCRIPTION
Adding the HEALTHCHECK instruction to the Dockerfile allows Docker to monitor the health of the container. This ensures that if the application inside the container becomes unhealthy (e.g., due to crashes or hanging), Docker can take appropriate actions, such as restarting the container. This is an essential part of maintaining a robust and reliable containerized application, and it mitigates potential issues by ensuring that the service remains operational and is promptly addressed when it is not.

**Severity**: low

NuLink used AI to generate this PR.